### PR TITLE
Pin GH actions to SHA to avoid mutable refs

### DIFF
--- a/.github/workflows/cf-versions.yml
+++ b/.github/workflows/cf-versions.yml
@@ -3,8 +3,6 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 14 * * MON'
-
-
 jobs:
   run:
     name: Fetch CurseForge Versions
@@ -12,13 +10,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-
       - name: Update CurseForge versions.json
         run: "curl https://minecraft.curseforge.com/api/game/versions?token=${{ secrets.CF_TOKEN }} | python -m json.tool > versions.json"
         shell: bash
-
       - name: Commit changes
-        uses: EndBug/add-and-commit@v9
+        uses: EndBug/add-and-commit@61a88be553afe4206585b31aa72387c64295d08b # ratchet:EndBug/add-and-commit@v9
         with:
           author_name: intellectualsites-bot
           author_email: "95638266+intellectualsites-bot@users.noreply.github.com"


### PR DESCRIPTION
GitHub actions are mutable if not pinned, which allow modifications without revision changes. Let's pin external versions to ensure the version specified matches the version GH action pulls.